### PR TITLE
Added missing service account step to installation example

### DIFF
--- a/doc/user/install_guide.md
+++ b/doc/user/install_guide.md
@@ -8,6 +8,14 @@ Set up basic [RBAC rules][rbac-rules] for etcd operator:
 $ example/rbac/create_role.sh
 ```
 
+## Set up service account
+
+Set up basic service account for etcd operator:
+
+```bash
+$ kubectl create -f example/serviceaccount.yaml
+```
+
 ## Install etcd operator
 
 Create a deployment for etcd operator:
@@ -36,6 +44,7 @@ Clean up etcd operator:
 
 ```bash
 kubectl delete -f example/deployment.yaml
+kubectl delete -f example/serviceaccount.yaml
 kubectl delete endpoints etcd-operator
 kubectl delete crd etcdclusters.etcd.database.coreos.com
 kubectl delete clusterrole etcd-operator


### PR DESCRIPTION
doc: updated installation guide

The installation guide was missing the step in regards to getting
the service account added. Although the deployment manifest loads
fine the operator never gets created since it is unable to find the
service account called "etcd-operator".